### PR TITLE
corrected HTML norm

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,11 @@
-<html>
+<!DOCTYPE html>
+<html lang="de-de">
+    <head>
+        <meta charset="utf-8" />
+        <title>Lottery</title>
+    </head>
     <body>
-        <div id="Input fields">
+        <div id="input_fields">
             Possible different numbers on the balls
             <input id="minNumber" placeholder="from" type="text">
             <input id="maxNumber" placeholder="to" type="text">


### PR DESCRIPTION
Hallo Frank.
Ich habe mir zuerst dein HTML vorgenommen und es nach der HTML5 Definition korrigiert.

1. Der DOCTYPE hat gefehlt. Laut der HTML5 Definition pflicht.
2. Der "Head" Tag hat gefehlt. 
3. Ein Meta-Tag zur Definition des charsets hat gefehlt.
4. Ein "Title" Tag fehlte.
5. Optional habe ich den "HTML" Tag um das "lang" Attribute erweitert.
Ist zwar nicht pflicht aber wird von  "https://validator.w3.org/" als Warning erkannt.